### PR TITLE
Seed books data for test user using Faker and Prisma seed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
+        "@faker-js/faker": "^9.9.0",
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
@@ -951,6 +952,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
+    "@faker-js/faker": "^9.9.0",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
@@ -82,5 +83,8 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "prisma": {
+    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   }
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,41 @@
+import { faker } from '@faker-js/faker';
+import { Genre, PrismaClient, ReadStatus } from '../src/generated/prisma';
+
+const prisma = new PrismaClient();
+
+const userIds = [1];
+
+async function main() {
+  console.log('Seeding book data...');
+  for (const userId of userIds) {
+    // delete all books of that user
+    await prisma.book.deleteMany({
+      where: {
+        userId: userId,
+      },
+    });
+    for (let i = 0; i < 30; i++) {
+      await prisma.book.create({
+        data: {
+          userId: userId,
+          title: faker.book.title(),
+          author: faker.book.author(),
+          genre: faker.helpers.enumValue(Genre),
+          owned: faker.datatype.boolean(),
+          readStatus: faker.helpers.enumValue(ReadStatus),
+          starred: faker.datatype.boolean(),
+        },
+      });
+    }
+  }
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/src/books/books.service.ts
+++ b/src/books/books.service.ts
@@ -32,6 +32,9 @@ export class BooksService {
     }
     const userBooks = await this.databaseService.book.findMany({
       where: whereClause,
+      omit: {
+        userId: true,
+      },
     });
     return userBooks;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "exclude": ["prisma/**/*"],
+  "include": ["./src/**/*"],
   "compilerOptions": {
     "module": "nodenext",
     "moduleResolution": "nodenext",


### PR DESCRIPTION
**Development tooling and database seeding:**

* Added a Prisma seed script (`prisma/seed.ts`) that uses Faker to generate 30 random book entries for each user, deleting existing books for the user before seeding. This script populates fields such as `title`, `author`, `genre`, `owned`, `readStatus`, and `starred`.
* Use `npx prisma db seed` to seed the database with books for user with `userId = 1`, notice this will first delete all the books of that user.

**Data privacy and API improvements:**

* Updated the `BooksService` in `src/books/books.service.ts` to omit the `userId` field from book results for `GET /user/books` service.